### PR TITLE
 Increase memory request and limit to avoid OOM error

### DIFF
--- a/infrastructure-components.yaml
+++ b/infrastructure-components.yaml
@@ -399,9 +399,9 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 100Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
       serviceAccountName: etcdadm-bootstrap-provider-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
After creating a simple (1-1-1) management cluster and a 1-1-1 workload cluster, the memory usage was around 25Mi which is over the memory request and close to the memory limit. A custom encountered OOM error when upgrading a cluster.

*Issue #, if available:*

*Description of changes:*
Increase the memory request/limit from 20Mi/30Mi to 50Mi/100Mi.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
