### PR TITLE
Increasing memory limits for etcdadm bootstrap provider in raw config file

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,9 +38,9 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 100Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
       terminationGracePeriodSeconds: 10
       serviceAccountName: manager


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The change was already made in infrastructure-components.yaml, but if users re-build the manifests, it will be overwritten. This change modifies the original files so they can be generated into manifests correctly


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
