### PR TITLE
Make adminImage and controlImage optional

### DIFF
--- a/api/v1beta1/etcdadmconfig_types.go
+++ b/api/v1beta1/etcdadmconfig_types.go
@@ -98,10 +98,12 @@ type BottlerocketConfig struct {
 	BootstrapImage string `json:"bootstrapImage"`
 
 	// AdminImage specifies the admin container image to use for bottlerocket.
-	AdminImage string `json:"adminImage"`
+	// +optional
+	AdminImage string `json:"adminImage,omitempty"`
 
 	// ControlImage specifies the control container image to use for bottlerocket.
-	ControlImage string `json:"controlImage"`
+	// +optional
+	ControlImage string `json:"controlImage,omitempty"`
 
 	// PauseImage specifies the image to use for the pause container
 	PauseImage string `json:"pauseImage"`

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_etcdadmconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_etcdadmconfigs.yaml
@@ -401,9 +401,7 @@ spec:
                       container
                     type: string
                 required:
-                - adminImage
                 - bootstrapImage
-                - controlImage
                 - pauseImage
                 type: object
               cipherSuites:


### PR DESCRIPTION
*Issue #, if available:*

Creating unstacked etcd without admin and control images specified will fail validation.

*Description of changes:*

Make adminImage and controlImage optional since right now only Snow provider requires the override.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
