### PR TITLE
registry mirror credentials for etcd machines

### DIFF
--- a/pkg/userdata/bottlerocket/template.go
+++ b/pkg/userdata/bottlerocket/template.go
@@ -29,7 +29,7 @@ func generateUserData(kind string, tpl string, data interface{}, input *userdata
 		return nil, err
 	}
 
-	return generateBottlerocketNodeUserData(bootstrapContainerUserData, input.Users, config, log)
+	return generateBottlerocketNodeUserData(bootstrapContainerUserData, input.Users, input.RegistryMirrorCredentials, config, log)
 }
 
 func generateBootstrapContainerUserData(kind string, tpl string, data interface{}) ([]byte, error) {

--- a/pkg/userdata/input.go
+++ b/pkg/userdata/input.go
@@ -40,6 +40,7 @@ type BaseUserData struct {
 	Mounts              []bootstrapv1.MountPoints
 	ControlPlane        bool
 	SentinelFileCommand string
+	RegistryMirrorCredentials
 }
 
 type EtcdadmArgs struct {
@@ -48,6 +49,11 @@ type EtcdadmArgs struct {
 	EtcdReleaseURL  string
 	InstallDir      string
 	CipherSuites    string
+}
+
+type RegistryMirrorCredentials struct {
+	Username string
+	Password string
 }
 
 func (args *EtcdadmArgs) SystemdFlags() []string {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added fields to support registry mirror authentication on unstacked etcd for Bottlerocket OS

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
