### PR TITLE
Set Etcd url from cloud-init config

### DIFF
--- a/pkg/userdata/input.go
+++ b/pkg/userdata/input.go
@@ -63,7 +63,7 @@ func (args *EtcdadmArgs) SystemdFlags() []string {
 	if args.Version != "" {
 		flags = append(flags, fmt.Sprintf("--version %s", args.Version))
 	}
-	if args.ImageRepository != "" {
+	if args.EtcdReleaseURL != "" {
 		flags = append(flags, fmt.Sprintf("--release-url %s", args.EtcdReleaseURL))
 	}
 	if args.InstallDir != "" {


### PR DESCRIPTION
*Description of changes:*
Non-Bottlerocket bootstrapping uses cloud-init module, and cloud-init config. The cloud-init config houses a EtcdReleaseURL and doesnt have an Image. Fixing this will help pass the right etcd url through userdata to etcdadm on the node.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
