### PR TITLE
Fix race condition with registry credentials secret for Bottlerocket etcd nodes

### DIFF
--- a/controllers/etcdadmconfig_controller.go
+++ b/controllers/etcdadmconfig_controller.go
@@ -248,6 +248,10 @@ func (r *EtcdadmConfigReconciler) initializeEtcd(ctx context.Context, scope *Sco
 	if scope.Config.Spec.RegistryMirror != nil {
 		username, password, err := r.resolveRegistryCredentials(ctx, scope.Config)
 		if err != nil {
+			if apierrors.IsNotFound(errors.Cause(err)) {
+				log.Info("Registry credentials secret not found yet, requeueing")
+				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+			}
 			log.Info("Cannot find secret for registry credentials, proceeding without registry credentials")
 		} else {
 			initInput.RegistryMirrorCredentials.Username = string(username)
@@ -333,6 +337,10 @@ func (r *EtcdadmConfigReconciler) joinEtcd(ctx context.Context, scope *Scope) (_
 	if scope.Config.Spec.RegistryMirror != nil {
 		username, password, err := r.resolveRegistryCredentials(ctx, scope.Config)
 		if err != nil {
+			if apierrors.IsNotFound(errors.Cause(err)) {
+				log.Info("Registry credentials secret not found yet, requeueing")
+				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+			}
 			log.Info("Cannot find secret for registry credentials, proceeding without registry credentials")
 		} else {
 			joinInput.RegistryMirrorCredentials.Username = string(username)

--- a/controllers/etcdadmconfig_controller.go
+++ b/controllers/etcdadmconfig_controller.go
@@ -207,7 +207,7 @@ func (r *EtcdadmConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return res, err
 	}
 
-	return ctrl.Result{}, nil
+	return res, nil
 }
 
 func (r *EtcdadmConfigReconciler) initializeEtcd(ctx context.Context, scope *Scope) (_ ctrl.Result, rerr error) {

--- a/controllers/etcdadmconfig_controller_test.go
+++ b/controllers/etcdadmconfig_controller_test.go
@@ -778,6 +778,162 @@ func newEtcdInitSecret(cluster *clusterv1.Cluster) *corev1.Secret {
 	}
 }
 
+// initializeEtcd should requeue when registry mirror is configured but credentials secret doesn't exist yet
+func TestEtcdadmConfigReconciler_InitializeEtcd_RequeueWhenRegistryCredentialsSecretMissing(t *testing.T) {
+	g := NewWithT(t)
+
+	cluster := newCluster("external-etcd-cluster")
+	machine := newMachine(cluster, "machine")
+	config := newEtcdadmConfig(machine, "etcdadmConfig", etcdbootstrapv1.Bottlerocket)
+	config.Spec.RegistryMirror = &etcdbootstrapv1.RegistryMirrorConfiguration{
+		Endpoint: "https://registry.example.com",
+	}
+
+	objects := []client.Object{
+		cluster,
+		machine,
+		config,
+		// intentionally NOT creating the registry-credentials secret
+	}
+	myclient := fake.NewClientBuilder().
+		WithScheme(setupScheme()).
+		WithObjects(objects...).
+		WithStatusSubresource(&etcdbootstrapv1.EtcdadmConfig{}).
+		Build()
+
+	k := &EtcdadmConfigReconciler{
+		Log:             log.Log,
+		Client:          myclient,
+		EtcdadmInitLock: &etcdInitLocker{},
+	}
+	request := ctrl.Request{
+		NamespacedName: client.ObjectKey{
+			Namespace: "default",
+			Name:      "etcdadmConfig",
+		},
+	}
+	result, err := k.Reconcile(ctx, request)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.RequeueAfter).To(Equal(10 * time.Second))
+}
+
+// initializeEtcd should include registry credentials in bootstrap data when secret exists
+func TestEtcdadmConfigReconciler_InitializeEtcd_IncludesRegistryCredentials(t *testing.T) {
+	g := NewWithT(t)
+
+	cluster := newCluster("external-etcd-cluster")
+	machine := newMachine(cluster, "machine")
+	config := newEtcdadmConfig(machine, "etcdadmConfig", etcdbootstrapv1.Bottlerocket)
+	config.Spec.RegistryMirror = &etcdbootstrapv1.RegistryMirrorConfiguration{
+		Endpoint: "https://registry.example.com",
+	}
+
+	registrySecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "registry-credentials",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"username": []byte("testuser"),
+			"password": []byte("testpass"),
+		},
+	}
+
+	objects := []client.Object{
+		cluster,
+		machine,
+		config,
+		registrySecret,
+	}
+	myclient := fake.NewClientBuilder().
+		WithScheme(setupScheme()).
+		WithObjects(objects...).
+		WithStatusSubresource(&etcdbootstrapv1.EtcdadmConfig{}).
+		Build()
+
+	k := &EtcdadmConfigReconciler{
+		Log:             log.Log,
+		Client:          myclient,
+		EtcdadmInitLock: &etcdInitLocker{},
+	}
+	request := ctrl.Request{
+		NamespacedName: client.ObjectKey{
+			Namespace: "default",
+			Name:      "etcdadmConfig",
+		},
+	}
+	result, err := k.Reconcile(ctx, request)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.Requeue).To(BeFalse())
+	g.Expect(result.RequeueAfter).To(BeZero())
+
+	configKey := client.ObjectKeyFromObject(config)
+	g.Expect(myclient.Get(context.TODO(), configKey, config)).To(Succeed())
+	c := v1beta1conditions.Get(config, etcdbootstrapv1.DataSecretAvailableCondition)
+	g.Expect(c).ToNot(BeNil())
+	g.Expect(c.Status).To(Equal(corev1.ConditionTrue))
+
+	bootstrapSecret := &corev1.Secret{}
+	err = myclient.Get(ctx, configKey, bootstrapSecret)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(bootstrapSecret.Data).To(Not(BeNil()))
+	bootstrapData := string(bootstrapSecret.Data["value"])
+	g.Expect(bootstrapData).To(ContainSubstring("testuser"))
+	g.Expect(bootstrapData).To(ContainSubstring("testpass"))
+}
+
+// joinEtcd should requeue when registry mirror is configured but credentials secret doesn't exist yet
+func TestEtcdadmConfigReconciler_JoinEtcd_RequeueWhenRegistryCredentialsSecretMissing(t *testing.T) {
+	g := NewWithT(t)
+
+	cluster := newCluster("external-etcd-cluster")
+	cluster.Status.ManagedExternalEtcdInitialized = true
+	conditions.Set(cluster, metav1.Condition{
+		Type:   string(clusterv1.ManagedExternalEtcdClusterInitializedCondition),
+		Status: metav1.ConditionTrue,
+	})
+	etcdInitSecret := newEtcdInitSecret(cluster)
+
+	machine := newMachine(cluster, "machine")
+	config := newEtcdadmConfig(machine, "etcdadmConfig", etcdbootstrapv1.Bottlerocket)
+	config.Spec.RegistryMirror = &etcdbootstrapv1.RegistryMirrorConfiguration{
+		Endpoint: "https://registry.example.com",
+	}
+
+	etcdCACerts := etcdCACertKeyPair()
+	g.Expect(etcdCACerts.Generate()).To(Succeed())
+	etcdCASecret := etcdCACerts[0].AsSecret(client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Name}, *metav1.NewControllerRef(config, etcdbootstrapv1.GroupVersion.WithKind("EtcdadmConfig")))
+
+	objects := []client.Object{
+		cluster,
+		machine,
+		etcdInitSecret,
+		etcdCASecret,
+		config,
+		// intentionally NOT creating the registry-credentials secret
+	}
+	myclient := fake.NewClientBuilder().
+		WithScheme(setupScheme()).
+		WithObjects(objects...).
+		WithStatusSubresource(&etcdbootstrapv1.EtcdadmConfig{}).
+		Build()
+
+	k := &EtcdadmConfigReconciler{
+		Log:             log.Log,
+		Client:          myclient,
+		EtcdadmInitLock: &etcdInitLocker{},
+	}
+	request := ctrl.Request{
+		NamespacedName: client.ObjectKey{
+			Namespace: "default",
+			Name:      "etcdadmConfig",
+		},
+	}
+	result, err := k.Reconcile(ctx, request)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.RequeueAfter).To(Equal(10 * time.Second))
+}
+
 type etcdInitLocker struct {
 	locked bool
 }


### PR DESCRIPTION
## Summary

- Fix a race condition where the etcdadm-bootstrap-provider generates Bottlerocket bootstrap userdata without registry mirror credentials, causing etcd nodes to fail image pulls through authenticated registry mirrors.
- When the `registry-credentials` secret is not yet available (applied in the same kubectl batch), requeue the reconciliation instead of silently proceeding without credentials.
- Fix: `Reconcile()` was discarding `joinEtcd`'s Result (including `RequeueAfter`) by returning `ctrl.Result{}` instead of `res`.

## Root Cause

The EKS-A CLI applies the `EtcdadmConfig` CR and the `registry-credentials` Secret in a single `kubectl apply` batch. The etcdadm-bootstrap-provider controller reconciles the `EtcdadmConfig` immediately, but the secret may not be persisted yet. The controller calls `resolveRegistryCredentials()`, gets a `NotFound` error, and proceeds to generate bootstrap data without the `[[settings.container-registry.credentials]]` TOML section.

On Bottlerocket, this means host containers (bootstrap, etcd) cannot authenticate to pull images through the mirror. Etcd never starts, and the cluster times out waiting for ControlPlaneReady.

## Fix

When `resolveRegistryCredentials` returns a `NotFound` error, requeue with a 10-second delay instead of silently continuing. This gives the API server time to persist the secret from the same apply batch.

Applied to both `initializeEtcd` and `joinEtcd` code paths.

Additionally fixed a bug where `Reconcile()` discarded `joinEtcd`'s `ctrl.Result` (returning `ctrl.Result{}` instead of `res`), which would have prevented the requeue from being honored in the join path.

## Testing

- [x] Unit test: verify `initializeEtcd` returns `RequeueAfter: 10s` when `registry-credentials` secret is missing
- [x] Unit test: verify credentials are included in bootstrap data when secret exists
- [x] Unit test: verify `joinEtcd` returns `RequeueAfter: 10s` when `registry-credentials` secret is missing
