### PR TITLE
Fix containerd v2 registry mirror auth for Bottlerocket etcd nodes

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,6 +20,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1.0
+          version: v2.12.2
           only-new-issues: true
           args: --timeout 10m

--- a/controllers/etcdadmconfig_controller.go
+++ b/controllers/etcdadmconfig_controller.go
@@ -18,8 +18,10 @@ package controllers
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -246,12 +248,15 @@ func (r *EtcdadmConfigReconciler) initializeEtcd(ctx context.Context, scope *Sco
 
 	// grab user pass for registry mirror
 	if scope.Config.Spec.RegistryMirror != nil {
+		initInput.RegistryMirrorCredentials.RegistryMirrorEndpoint = stripEndpointPath(scope.Config.Spec.RegistryMirror.Endpoint)
 		username, password, err := r.resolveRegistryCredentials(ctx, scope.Config)
 		if err != nil {
 			log.Info("Cannot find secret for registry credentials, proceeding without registry credentials")
 		} else {
 			initInput.RegistryMirrorCredentials.Username = string(username)
 			initInput.RegistryMirrorCredentials.Password = string(password)
+			initInput.RegistryMirrorCredentials.RegistryMirrorCredentialEncoded = base64.StdEncoding.EncodeToString(
+				[]byte(fmt.Sprintf("%s:%s", username, password)))
 		}
 	}
 
@@ -331,12 +336,15 @@ func (r *EtcdadmConfigReconciler) joinEtcd(ctx context.Context, scope *Scope) (_
 
 	// grab user pass for registry mirror
 	if scope.Config.Spec.RegistryMirror != nil {
+		joinInput.RegistryMirrorCredentials.RegistryMirrorEndpoint = stripEndpointPath(scope.Config.Spec.RegistryMirror.Endpoint)
 		username, password, err := r.resolveRegistryCredentials(ctx, scope.Config)
 		if err != nil {
 			log.Info("Cannot find secret for registry credentials, proceeding without registry credentials")
 		} else {
 			joinInput.RegistryMirrorCredentials.Username = string(username)
 			joinInput.RegistryMirrorCredentials.Password = string(password)
+			joinInput.RegistryMirrorCredentials.RegistryMirrorCredentialEncoded = base64.StdEncoding.EncodeToString(
+				[]byte(fmt.Sprintf("%s:%s", username, password)))
 		}
 	}
 
@@ -426,6 +434,14 @@ func (r *EtcdadmConfigReconciler) storeBootstrapData(ctx context.Context, config
 	config.Status.Ready = true
 	v1beta1conditions.MarkTrue(config, bootstrapv1.DataSecretAvailableCondition)
 	return nil
+}
+
+// stripEndpointPath extracts the host:port from an endpoint that may contain a path (e.g. "192.168.1.1:443/v2" -> "192.168.1.1:443").
+func stripEndpointPath(endpoint string) string {
+	if idx := strings.Index(endpoint, "/"); idx != -1 {
+		return endpoint[:idx]
+	}
+	return endpoint
 }
 
 func (r *EtcdadmConfigReconciler) resolveRegistryCredentials(ctx context.Context, config *etcdbootstrapv1.EtcdadmConfig) ([]byte, []byte, error) {

--- a/pkg/userdata/bottlerocket/etcd_init.go
+++ b/pkg/userdata/bottlerocket/etcd_init.go
@@ -14,6 +14,9 @@ const etcdInitCloudInit = `{{.Header}}
     owner: root:root
     permissions: '0640'
     content: "This placeholder file is used to create the /run/cluster-api sub directory in a way that is compatible with both Linux and Windows (mkdir -p /run/cluster-api does not work with Windows)"
+{{- if (ne .RegistryMirrorCredentialEncoded "")}}
+{{template "registryMirrorHostsTomlSettings" .}}
+{{- end }}
 runcmd: "{{ .EtcdadmInitCommand }}"
 `
 

--- a/pkg/userdata/bottlerocket/etcd_join.go
+++ b/pkg/userdata/bottlerocket/etcd_join.go
@@ -16,6 +16,9 @@ const (
     owner: root:root
     permissions: '0640'
     content: "This placeholder file is used to create the /run/cluster-api sub directory in a way that is compatible with both Linux and Windows (mkdir -p /run/cluster-api does not work with Windows)"
+{{- if (ne .RegistryMirrorCredentialEncoded "")}}
+{{template "registryMirrorHostsTomlSettings" .}}
+{{- end }}
 runcmd: "{{ .EtcdadmJoinCommand }}"
 `
 )

--- a/pkg/userdata/bottlerocket/node_userdata.go
+++ b/pkg/userdata/bottlerocket/node_userdata.go
@@ -157,21 +157,21 @@ trusted = true
 )
 
 type bottlerocketSettingsInput struct {
-	PauseContainerSource       string
-	HTTPSProxyEndpoint         string
-	NoProxyEndpoints           []string
-	RegistryMirrorEndpoint     string
+	PauseContainerSource         string
+	HTTPSProxyEndpoint           string
+	NoProxyEndpoints             []string
+	RegistryMirrorEndpoint       string
 	RegistryMirrorCredentialHost string
-	RegistryMirrorCACert       string
-	RegistryMirrorUsername     string
-	RegistryMirrorPassword     string
-	Hostname                   string
-	HostContainers             []etcdbootstrapv1.BottlerocketHostContainer
-	BootstrapContainers        []etcdbootstrapv1.BottlerocketBootstrapContainer
-	NTPServers                 []string
-	SysctlSettings             string
-	BootKernel                 string
-	CertBundles                []bootstrapv1.CertBundle
+	RegistryMirrorCACert         string
+	RegistryMirrorUsername       string
+	RegistryMirrorPassword       string
+	Hostname                     string
+	HostContainers               []etcdbootstrapv1.BottlerocketHostContainer
+	BootstrapContainers          []etcdbootstrapv1.BottlerocketBootstrapContainer
+	NTPServers                   []string
+	SysctlSettings               string
+	BootKernel                   string
+	CertBundles                  []bootstrapv1.CertBundle
 }
 
 // generateBottlerocketNodeUserData returns the userdata for the host bottlerocket in toml format
@@ -228,7 +228,7 @@ func generateBottlerocketNodeUserData(kubeadmBootstrapContainerUserData []byte, 
 
 	if config.RegistryMirror != nil {
 		bottlerocketInput.RegistryMirrorEndpoint = registryHost(config.RegistryMirror.Endpoint)
-		bottlerocketInput.RegistryMirrorCredentialHost = registryHost(config.RegistryMirror.Endpoint)
+		bottlerocketInput.RegistryMirrorCredentialHost = registryHostNoPort(config.RegistryMirror.Endpoint)
 		if config.RegistryMirror.CACert != "" {
 			bottlerocketInput.RegistryMirrorCACert = base64.StdEncoding.EncodeToString([]byte(config.RegistryMirror.CACert))
 		}
@@ -324,12 +324,23 @@ func generateAdminContainerUserData(kind string, tpl string, data interface{}) (
 
 // registryHost extracts the host:port portion from an endpoint that may contain
 // a path component (e.g. "192.168.1.1:443/v2" -> "192.168.1.1:443").
-// Bottlerocket matches credentials by host:port only.
 func registryHost(endpoint string) string {
 	if idx := strings.Index(endpoint, "/"); idx != -1 {
 		return endpoint[:idx]
 	}
 	return endpoint
+}
+
+// registryHostNoPort extracts just the hostname from an endpoint, stripping
+// both path and port (e.g. "192.168.1.1:443/v2" -> "192.168.1.1").
+// Bottlerocket generates containerd credential directories without the port,
+// so the credentials registry field must match.
+func registryHostNoPort(endpoint string) string {
+	host := registryHost(endpoint)
+	if idx := strings.LastIndex(host, ":"); idx != -1 {
+		return host[:idx]
+	}
+	return host
 }
 
 func generateNodeUserData(kind string, tpl string, data interface{}) ([]byte, error) {

--- a/pkg/userdata/bottlerocket/node_userdata.go
+++ b/pkg/userdata/bottlerocket/node_userdata.go
@@ -86,6 +86,20 @@ username = "{{.RegistryMirrorUsername}}"
 password = "{{.RegistryMirrorPassword}}"
 {{- end -}}
 `
+	registryMirrorHostsTomlTemplate = `{{ define "registryMirrorHostsTomlSettings" -}}
+-   path: /etc/containerd/certs.d/public.ecr.aws/hosts.toml
+    owner: root:root
+    permissions: '0644'
+    content: |
+      server = "https://public.ecr.aws"
+
+      [host."https://{{.RegistryMirrorEndpoint}}"]
+        capabilities = ["pull", "resolve"]
+
+      [host."https://{{.RegistryMirrorEndpoint}}".header]
+        authorization = "Basic {{.RegistryMirrorCredentialEncoded}}"
+{{- end -}}
+`
 	ntpTemplate = `{{ define "ntpSettings" -}}
 [settings.ntp]
 time-servers = [{{stringsJoin .NTPServers ", " }}]
@@ -163,9 +177,10 @@ type bottlerocketSettingsInput struct {
 	RegistryMirrorEndpoint       string
 	RegistryMirrorCredentialHost string
 	RegistryMirrorCACert         string
-	RegistryMirrorUsername       string
-	RegistryMirrorPassword       string
-	Hostname                     string
+	RegistryMirrorUsername          string
+	RegistryMirrorPassword          string
+	RegistryMirrorCredentialEncoded string
+	Hostname                        string
 	HostContainers               []etcdbootstrapv1.BottlerocketHostContainer
 	BootstrapContainers          []etcdbootstrapv1.BottlerocketBootstrapContainer
 	NTPServers                   []string
@@ -234,6 +249,10 @@ func generateBottlerocketNodeUserData(kubeadmBootstrapContainerUserData []byte, 
 		}
 		bottlerocketInput.RegistryMirrorUsername = registryMirrorCredentials.Username
 		bottlerocketInput.RegistryMirrorPassword = registryMirrorCredentials.Password
+		if registryMirrorCredentials.Username != "" && registryMirrorCredentials.Password != "" {
+			bottlerocketInput.RegistryMirrorCredentialEncoded = base64.StdEncoding.EncodeToString(
+				[]byte(fmt.Sprintf("%s:%s", registryMirrorCredentials.Username, registryMirrorCredentials.Password)))
+		}
 	}
 
 	if config.NTP != nil && config.NTP.Enabled != nil && *config.NTP.Enabled {

--- a/pkg/userdata/bottlerocket/node_userdata.go
+++ b/pkg/userdata/bottlerocket/node_userdata.go
@@ -81,7 +81,7 @@ registry = "public.ecr.aws"
 username = "{{.RegistryMirrorUsername}}"
 password = "{{.RegistryMirrorPassword}}"
 [[settings.container-registry.credentials]]
-registry = "{{.RegistryMirrorEndpoint}}"
+registry = "{{.RegistryMirrorCredentialHost}}"
 username = "{{.RegistryMirrorUsername}}"
 password = "{{.RegistryMirrorPassword}}"
 {{- end -}}
@@ -157,20 +157,21 @@ trusted = true
 )
 
 type bottlerocketSettingsInput struct {
-	PauseContainerSource   string
-	HTTPSProxyEndpoint     string
-	NoProxyEndpoints       []string
-	RegistryMirrorEndpoint string
-	RegistryMirrorCACert   string
-	RegistryMirrorUsername string
-	RegistryMirrorPassword string
-	Hostname               string
-	HostContainers         []etcdbootstrapv1.BottlerocketHostContainer
-	BootstrapContainers    []etcdbootstrapv1.BottlerocketBootstrapContainer
-	NTPServers             []string
-	SysctlSettings         string
-	BootKernel             string
-	CertBundles            []bootstrapv1.CertBundle
+	PauseContainerSource       string
+	HTTPSProxyEndpoint         string
+	NoProxyEndpoints           []string
+	RegistryMirrorEndpoint     string
+	RegistryMirrorCredentialHost string
+	RegistryMirrorCACert       string
+	RegistryMirrorUsername     string
+	RegistryMirrorPassword     string
+	Hostname                   string
+	HostContainers             []etcdbootstrapv1.BottlerocketHostContainer
+	BootstrapContainers        []etcdbootstrapv1.BottlerocketBootstrapContainer
+	NTPServers                 []string
+	SysctlSettings             string
+	BootKernel                 string
+	CertBundles                []bootstrapv1.CertBundle
 }
 
 // generateBottlerocketNodeUserData returns the userdata for the host bottlerocket in toml format
@@ -227,6 +228,7 @@ func generateBottlerocketNodeUserData(kubeadmBootstrapContainerUserData []byte, 
 
 	if config.RegistryMirror != nil {
 		bottlerocketInput.RegistryMirrorEndpoint = config.RegistryMirror.Endpoint
+		bottlerocketInput.RegistryMirrorCredentialHost = registryHost(config.RegistryMirror.Endpoint)
 		if config.RegistryMirror.CACert != "" {
 			bottlerocketInput.RegistryMirrorCACert = base64.StdEncoding.EncodeToString([]byte(config.RegistryMirror.CACert))
 		}
@@ -318,6 +320,16 @@ func generateAdminContainerUserData(kind string, tpl string, data interface{}) (
 		return nil, errors.Wrapf(err, "failed to generate %s template", kind)
 	}
 	return out.Bytes(), nil
+}
+
+// registryHost extracts the host:port portion from an endpoint that may contain
+// a path component (e.g. "192.168.1.1:443/v2" -> "192.168.1.1:443").
+// Bottlerocket matches credentials by host:port only.
+func registryHost(endpoint string) string {
+	if idx := strings.Index(endpoint, "/"); idx != -1 {
+		return endpoint[:idx]
+	}
+	return endpoint
 }
 
 func generateNodeUserData(kind string, tpl string, data interface{}) ([]byte, error) {

--- a/pkg/userdata/bottlerocket/node_userdata.go
+++ b/pkg/userdata/bottlerocket/node_userdata.go
@@ -227,7 +227,7 @@ func generateBottlerocketNodeUserData(kubeadmBootstrapContainerUserData []byte, 
 	}
 
 	if config.RegistryMirror != nil {
-		bottlerocketInput.RegistryMirrorEndpoint = config.RegistryMirror.Endpoint
+		bottlerocketInput.RegistryMirrorEndpoint = registryHost(config.RegistryMirror.Endpoint)
 		bottlerocketInput.RegistryMirrorCredentialHost = registryHost(config.RegistryMirror.Endpoint)
 		if config.RegistryMirror.CACert != "" {
 			bottlerocketInput.RegistryMirrorCACert = base64.StdEncoding.EncodeToString([]byte(config.RegistryMirror.CACert))

--- a/pkg/userdata/bottlerocket/node_userdata_test.go
+++ b/pkg/userdata/bottlerocket/node_userdata_test.go
@@ -136,7 +136,7 @@ pod-infra-container-image = "pause-image"
 [settings.network]
 hostname = ""
 [settings.container-registry.mirrors]
-"public.ecr.aws" = ["https://registry-endpoint"]
+"public.ecr.aws" = ["https://registry-endpoint:443/v2"]
 [settings.pki.registry-mirror-ca]
 data = "Y2FjZXJ0"
 trusted=true
@@ -145,7 +145,7 @@ registry = "public.ecr.aws"
 username = "username"
 password = "password"
 [[settings.container-registry.credentials]]
-registry = "registry-endpoint"
+registry = "registry-endpoint:443"
 username = "username"
 password = "password"`
 
@@ -437,7 +437,7 @@ func TestGenerateBottlerocketNodeUserData(t *testing.T) {
 					PauseImage:     "pause-image",
 				},
 				RegistryMirror: &v1beta1.RegistryMirrorConfiguration{
-					Endpoint: "registry-endpoint",
+					Endpoint: "registry-endpoint:443/v2",
 					CACert:   "cacert",
 				},
 			},

--- a/pkg/userdata/bottlerocket/node_userdata_test.go
+++ b/pkg/userdata/bottlerocket/node_userdata_test.go
@@ -136,7 +136,7 @@ pod-infra-container-image = "pause-image"
 [settings.network]
 hostname = ""
 [settings.container-registry.mirrors]
-"public.ecr.aws" = ["https://registry-endpoint:443/v2"]
+"public.ecr.aws" = ["https://registry-endpoint:443"]
 [settings.pki.registry-mirror-ca]
 data = "Y2FjZXJ0"
 trusted=true

--- a/pkg/userdata/bottlerocket/node_userdata_test.go
+++ b/pkg/userdata/bottlerocket/node_userdata_test.go
@@ -145,7 +145,7 @@ registry = "public.ecr.aws"
 username = "username"
 password = "password"
 [[settings.container-registry.credentials]]
-registry = "registry-endpoint:443"
+registry = "registry-endpoint"
 username = "username"
 password = "password"`
 

--- a/pkg/userdata/bottlerocket/template.go
+++ b/pkg/userdata/bottlerocket/template.go
@@ -37,6 +37,9 @@ func generateBootstrapContainerUserData(kind string, tpl string, data interface{
 	if _, err := tm.Parse(filesTemplate); err != nil {
 		return nil, errors.Wrap(err, "failed to parse files template")
 	}
+	if _, err := tm.Parse(registryMirrorHostsTomlTemplate); err != nil {
+		return nil, errors.Wrap(err, "failed to parse registry mirror hosts.toml template")
+	}
 
 	t, err := tm.Parse(tpl)
 	if err != nil {

--- a/pkg/userdata/input.go
+++ b/pkg/userdata/input.go
@@ -54,8 +54,10 @@ type EtcdadmArgs struct {
 }
 
 type RegistryMirrorCredentials struct {
-	Username string
-	Password string
+	Username                       string
+	Password                       string
+	RegistryMirrorEndpoint         string
+	RegistryMirrorCredentialEncoded string
 }
 
 func (args *EtcdadmArgs) SystemdFlags() []string {


### PR DESCRIPTION
## Summary

Fixes containerd v2 registry mirror auth for Bottlerocket etcd nodes by adding `hosts.toml` with inline authorization headers to the bootstrap container write_files.

## Root Cause

Bottlerocket 1.62.0 with containerd 2.1.7 (k8s-1.33+ variants) does not read `credentials.toml` from `certs.d/` in the CRI image pull path. Additionally, `thar-be-registries` atomically swaps the `certs.d/` directory, so writes to the container-visible path land in the old directory.

## Fix

Adds a `registryMirrorHostsTomlTemplate` that writes `hosts.toml` with `[host."...".header] authorization = "Basic <base64>"` as a `write_files` entry in the bootstrap container cloud-config. Combined with the patched `bottlerocket-bootstrap` container (which writes to `/.bottlerocket/rootfs/etc/containerd/certs.d/` instead of `/etc/containerd/certs.d/`), this fixes the auth issue.

The existing `credentials.toml` rendering via `settings.container-registry` is kept for backwards compatibility with `host-ctr` and containerd 1.x.

## Verification

Tested end-to-end on cluster `cluster-133-dev-write` (Bottlerocket k8s-1.34, vmware provider, authenticated registry mirror):
- etcd node (195.18.68.69): hosts.toml has auth header, etcd running, health check passed
- Build compiles with Go 1.26

## Images for testing

| Component | Image |
|-----------|-------|
| etcdadm-bootstrap-provider | `public.ecr.aws/p2x5x2t2/aws/etcdadm-bootstrap-provider:v0.1.0-dev-write-file` |
| bottlerocket-bootstrap (required) | `public.ecr.aws/p2x5x2t2/bottlerocket-bootstrap:v0.1.0-dev-write-file` |

## Compatibility

Based on and compatible with #58 (Fix Bottlerocket registry credential endpoint mismatch).

## Dependencies

This PR requires the patched `bottlerocket-bootstrap` image (from [eks-anywhere-build-tooling PR #5571](https://github.com/aws/eks-anywhere-build-tooling/pull/5571)) to write files to the correct rootfs path.

## Test plan

- [x] etcd node: hosts.toml written with auth, etcd starts and passes health check
- [x] Backwards compatible: k8s-1.32 unaffected