### PR TITLE
Use registryHost instead of registryHostNoPort for credential registry

### DIFF
--- a/pkg/userdata/bottlerocket/node_userdata.go
+++ b/pkg/userdata/bottlerocket/node_userdata.go
@@ -228,7 +228,7 @@ func generateBottlerocketNodeUserData(kubeadmBootstrapContainerUserData []byte, 
 
 	if config.RegistryMirror != nil {
 		bottlerocketInput.RegistryMirrorEndpoint = registryHost(config.RegistryMirror.Endpoint)
-		bottlerocketInput.RegistryMirrorCredentialHost = registryHostNoPort(config.RegistryMirror.Endpoint)
+		bottlerocketInput.RegistryMirrorCredentialHost = registryHost(config.RegistryMirror.Endpoint)
 		if config.RegistryMirror.CACert != "" {
 			bottlerocketInput.RegistryMirrorCACert = base64.StdEncoding.EncodeToString([]byte(config.RegistryMirror.CACert))
 		}

--- a/pkg/userdata/bottlerocket/node_userdata.go
+++ b/pkg/userdata/bottlerocket/node_userdata.go
@@ -331,17 +331,6 @@ func registryHost(endpoint string) string {
 	return endpoint
 }
 
-// registryHostNoPort extracts just the hostname from an endpoint, stripping
-// both path and port (e.g. "192.168.1.1:443/v2" -> "192.168.1.1").
-// Bottlerocket generates containerd credential directories without the port,
-// so the credentials registry field must match.
-func registryHostNoPort(endpoint string) string {
-	host := registryHost(endpoint)
-	if idx := strings.LastIndex(host, ":"); idx != -1 {
-		return host[:idx]
-	}
-	return host
-}
 
 func generateNodeUserData(kind string, tpl string, data interface{}) ([]byte, error) {
 	tm := template.New(kind).Funcs(template.FuncMap{"stringsJoin": strings.Join})

--- a/pkg/userdata/bottlerocket/node_userdata_test.go
+++ b/pkg/userdata/bottlerocket/node_userdata_test.go
@@ -145,7 +145,7 @@ registry = "public.ecr.aws"
 username = "username"
 password = "password"
 [[settings.container-registry.credentials]]
-registry = "registry-endpoint"
+registry = "registry-endpoint:443"
 username = "username"
 password = "password"`
 


### PR DESCRIPTION
**Description:**
On containerd 1.7 (k8s-1.32 and earlier), the credential lookup in config.toml uses the full host:port from the mirror endpoint URL. Using registryHostNoPort() strips the port, producing a config key like registry.configs."196.18.89.98".auth, but containerd looks up "196.18.89.98:443" — causing "no basic auth credentials" failures.

Change to registryHost() which keeps the port (strips only the /v2 path).


**Testing**
- Build the dev images based on the change
- Create a k8s 1-32 EKS-A cluster

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
